### PR TITLE
Link license file in README and fix meta/main.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here's an example!
 License
 -------
 
-TBD
+[Apache 2.0](License)
 
 Author Information
 ------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,16 +8,9 @@ galaxy_info:
   # next line and provide a value
   # issue_tracker_url: http://example.com/issue/tracker
 
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
-  license: TBD
+  license: Apache
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.2
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -51,6 +44,15 @@ galaxy_info:
       versions:
         - '10.12'
 
-  galaxy_tags: [sdkman]
+  galaxy_tags:
+    - ci
+    - development
+    - gradle
+    - groovy
+    - java
+    - maven
+    - sbt
+    - scala
+    - sdkman
 
 dependencies: []


### PR DESCRIPTION
There should be more galaxy tags to make it easy to find the role
in Ansible Galaxy. The License should be made obvious for consumers
of the role.