### PR TITLE
Fix the ID for the Galaxy role badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ Author Information
 [galaxy-link]: https://galaxy.ansible.com/Comcast/sdkman/
 [license-badge]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-link]: https://raw.githubusercontent.com/Comcast/ansible-sdkman/master/LICENSE
-[role-badge]: https://img.shields.io/ansible/role/17404.svg
+[role-badge]: https://img.shields.io/ansible/role/20938.svg
 [travis-badge]: https://api.travis-ci.org/Comcast/ansible-sdkman.svg?branch=master
 [travis-link]: https://travis-ci.org/Comcast/ansible-sdkman


### PR DESCRIPTION
Since the role was re-imported in Ansible Galaxy, Ansible Galaxy
believes it is a totally different role (with a new ID). This change
fixes the Ansible Galaxy badge.