### PR TITLE
Bugfix: Set SDKMAN_DIR for included tasks

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: Apache
 
-  min_ansible_version: 2.4
+  min_ansible_version: '2.5.2'
 
   platforms:
     - name: Alpine

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,7 +23,8 @@
   become: yes
   with_items: '{{ system_packages }}'
 
-- include: install_glibc_alpine.yml
+- name: Install GLIBC for Alpine Linux
+  include_tasks: install_glibc_alpine.yml
   when: ansible_os_family == 'Alpine'
 
 - name: Check for SDKMAN installation

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,12 @@
 ---
 # tasks file for ansible-sdkman
 
-- include_tasks: install.yml
+- name: Install SDKMAN
+  include_tasks: install.yml
 
-- include_tasks: sdkman.yml
+- block:
+    - name: Run SDKMAN tasks
+      include_tasks: sdkman.yml
   environment:
     SDKMAN_DIR: '{{ sdkman_dir }}'
   become: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,8 +1,6 @@
 ---
 - name: Test SDKMAN role
   hosts: all
-  environment:
-    SDKMAN_DIR: /usr/local/sdkman
   roles:
     - role: ansible-sdkman
       sdkman_dir: /usr/local/sdkman


### PR DESCRIPTION
By applying the suggestion [here](https://github.com/ansible/ansible/issues/42990#issuecomment-406862950),
this change ensures that the `SDKMAN_DIR` environment variable is set correctly within included tasks.

Fixes #21