### PR TITLE
Bump paramiko version to latest patch version

### DIFF
--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -36,7 +36,7 @@ mccabe==0.6.1
 molecule==2.17.0
 monotonic==1.5
 more-itertools==4.2.0
-paramiko==2.4.1
+paramiko==2.4.2
 pathspec==0.5.6
 pbr==4.1.0
 pexpect==4.6.0


### PR DESCRIPTION
update paramiko to latest patch version for [CVE-2018-7750](https://www.cvedetails.com/cve/CVE-2018-7750/).

The risk here is pretty low since its part of the testing workflow, but definitely worth updating.