### PR TITLE
Update Alpine GLIBC packages to 2.28-r0

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -41,7 +41,7 @@ rules:
   key-duplicates: enable
   key-ordering: disable
   line-length:
-    max: 80
+    max: 120
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: false
   new-line-at-end-of-file: enable

--- a/tasks/install_glibc_alpine.yml
+++ b/tasks/install_glibc_alpine.yml
@@ -25,7 +25,7 @@
 
 - name: Add sgerrand's public key
   get_url:
-    url: '{{ alpine_glibc_download_url }}/sgerrand.rsa.pub'
+    url: '{{ alpine_glibc_pubkey_url }}'
     dest: /etc/apk/keys/
 
 - name: Install GLIBC for Alpine Linux
@@ -33,6 +33,7 @@
     name: '{{ sdkman_tmp_dir }}/{{ item }}-{{ alpine_glibc_version }}.apk'
     state: present
   with_items: '{{ alpine_glibc_pkgs_to_install }}'
+  become: yes
 
 - name: Cleanup GLIBC apk files
   file:

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -9,13 +9,11 @@ system_packages:
   - unzip
   - zip
 
-alpine_glibc_version: 2.25-r0
-alpine_glibc_base_url: >-
-alpine_glibc_download_url: "https://github.com/sgerrand/alpine-pkg-glibc/\
-                            releases/download/\
-                            {{ alpine_glibc_base_url }}/\
-                            {{ alpine_glibc_version }}"
+alpine_glibc_version: 2.28-r0
+alpine_glibc_download_url: https://github.com/sgerrand/alpine-pkg-glibc/releases/download/{{ alpine_glibc_version }}
+alpine_glibc_pubkey_url: https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 alpine_glibc_pkg_names:
   - glibc
   - glibc-bin
+  - glibc-dev
   - glibc-i18n


### PR DESCRIPTION
The Alpine GLIBC packages haven't been updated in a while, so this
change updates to the latest available release in Sasha Gerrand's
repository. The GPG public key URL has changed and is no longer
packaged along with GLIBC releases.

It's easier to read variables when they're not declared across
several lines, so I've decided to relax the maximum line length to
120 characters.

Finally, this change explicitly invokes privilege escalation in order
to install the GLIBC packages. Since the CI process has been using
the `root` user inside the official Alpine Docker image(s), this
was easy to miss.