### PR TITLE
Add offline mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,3 +52,7 @@ sdkman_defaults: {}
 # Reference: http://sdkman.io/usage (Flush section)
 sdkman_flush_caches_before: []
 sdkman_flush_caches_after: []
+
+# Set SDKMAN to offline mode
+# Reference: https://sdkman.io/usage#offline
+sdkman_offline_mode: false

--- a/tasks/sdkman.yml
+++ b/tasks/sdkman.yml
@@ -1,6 +1,12 @@
 ---
 # tasks for managing SDKMAN!
 
+- name: Disable SDKMAN offline mode
+  shell: . {{ sdkman_dir }}/bin/sdkman-init.sh && sdk offline disable
+  args:
+    executable: /bin/bash
+  changed_when: false
+
 - name: Configure SDKMAN
   template:
     src: templates/sdkman_config.j2

--- a/tasks/sdkman.yml
+++ b/tasks/sdkman.yml
@@ -76,3 +76,10 @@
     executable: /bin/bash
   loop: '{{ sdkman_flush_caches_after }}'
   changed_when: false
+
+- name: Enable SDKMAN offline mode
+  shell: . {{ sdkman_dir }}/bin/sdkman-init.sh && sdk offline enable
+  args:
+    executable: /bin/bash
+  when: sdkman_offline_mode
+  changed_when: false

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,7 +15,7 @@
           version: 1.8.9
       sdkman_install_packages:
         - candidate: java
-          version: 8.0.192-zulu
+          version: 8.0.201-zulu
         - candidate: gradle
           version: '4.6'
         - candidate: gradle


### PR DESCRIPTION
### Description
Fixes Issue https://github.com/Comcast/ansible-sdkman/issues/38.

Add new role variable `sdkman_offline_mode` for enabling [offline mode](https://sdkman.io/usage#offline) as the final configuration step. This is paired with a step that runs regardless at the start to ensure offline mode is disabled in case it was set on a preexisting installation.