### PR TITLE
Bugfix for #37

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,7 +14,6 @@
     getent passwd {{ sdkman_user }} | cut -d: -f6
     {%- endif -%}
   register: sdkman_user_home_dir
-  when: sdkman_dir is undefined
   changed_when: false
 
 - name: Set SDKMAN_DIR environment variable


### PR DESCRIPTION
Patches task `Determine SDKMAN user HOME directory` to run
even when the `sdkman_dir` is set by the user. This prevents the
subsequent task from failing.