### PR TITLE
Offline mode tests

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,6 @@
       include_tasks: sdkman.yml
   environment:
     SDKMAN_DIR: '{{ sdkman_dir }}'
+    SDKMAN_OFFLINE_MODE: 'false'
   become: '{{ sdkman_user != ansible_user_id }}'
   become_user: '{{ sdkman_user }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,16 @@
 - block:
     - name: Run SDKMAN tasks
       include_tasks: sdkman.yml
+
+    - name: Persist additional SDKMAN environment variables
+      include_tasks: persist_env.yml
+      loop:
+        - .bash_profile
+        - .profile
+        - .bashrc
+        - .zshrc
+      loop_control:
+        loop_var: sdkman_profile
   environment:
     SDKMAN_DIR: '{{ sdkman_dir }}'
     SDKMAN_OFFLINE_MODE: 'false'

--- a/tasks/persist_env.yml
+++ b/tasks/persist_env.yml
@@ -1,0 +1,19 @@
+---
+# tasks for persisting SDKMAN environment variables in shell configs
+
+- name: "Set {{ sdkman_profile }} path"
+  set_fact:
+    sdkman_profile_path: '{{ sdkman_user_home_dir.stdout }}/{{ sdkman_profile }}'
+
+- name: "Detect settings in {{ sdkman_profile_path }}"
+  command: "grep 'sdkman-init.sh' '{{ sdkman_profile_path }}'"
+  changed_when: false
+  ignore_errors: true
+  register: sdkman_profile_result
+
+- name: "Add SDKMAN_OFFLINE_MODE to {{ sdkman_profile_path }}"
+  lineinfile:
+    path: "{{ sdkman_profile_path }}"
+    regexp: '^export SDKMAN_OFFLINE_MODE='
+    line: "export SDKMAN_OFFLINE_MODE={{ 'true' if sdkman_offline_mode else 'false' }}"
+  when: sdkman_profile_result.rc == 0

--- a/tasks/sdkman.yml
+++ b/tasks/sdkman.yml
@@ -1,12 +1,6 @@
 ---
 # tasks for managing SDKMAN!
 
-- name: Disable SDKMAN offline mode
-  shell: . {{ sdkman_dir }}/bin/sdkman-init.sh && sdk offline disable
-  args:
-    executable: /bin/bash
-  changed_when: false
-
 - name: Configure SDKMAN
   template:
     src: templates/sdkman_config.j2

--- a/tasks/sdkman.yml
+++ b/tasks/sdkman.yml
@@ -76,10 +76,3 @@
     executable: /bin/bash
   loop: '{{ sdkman_flush_caches_after }}'
   changed_when: false
-
-- name: Enable SDKMAN offline mode
-  shell: . {{ sdkman_dir }}/bin/sdkman-init.sh && sdk offline enable
-  args:
-    executable: /bin/bash
-  when: sdkman_offline_mode
-  changed_when: false

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -29,3 +29,4 @@
         - archives
         - temp
       sdkman_validate_ssl: true
+      sdkman_offline_mode: true

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,7 +15,7 @@
           version: 1.8.9
       sdkman_install_packages:
         - candidate: java
-          version: 8.0.201-zulu
+          version: 8.0.202-zulu
         - candidate: gradle
           version: '4.6'
         - candidate: gradle

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -38,6 +38,7 @@ def test_other_gradle_installed(host):
     expected = 'Gradle 3.5.1'
     check_run_for_rc_and_result(cmds, expected, host)
 
+
 def test_offline(host):
     cmds = ['sdk list gradle']
     expected = 'Offline: only showing installed gradle versions'

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -37,3 +37,8 @@ def test_other_gradle_installed(host):
     cmds = ['sdk use gradle 3.5.1', 'gradle --version']
     expected = 'Gradle 3.5.1'
     check_run_for_rc_and_result(cmds, expected, host)
+
+def test_offline(host):
+    cmds = ['sdk list gradle']
+    expected = 'Offline: only showing installed gradle versions'
+    check_run_for_rc_and_result(cmds, expected, host)

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -20,8 +20,8 @@ def check_run_for_rc_and_result(cmds, expected, host, check_stderr=False):
 
 
 def test_config_file(host):
-    result = host.run(script_wrap(['echo $HOME']))
-    config_file_path = "{0}/.sdkman/etc/config".format(result.stdout)
+    result = host.run(script_wrap(['echo $SDKMAN_DIR']))
+    config_file_path = "{0}/etc/config".format(result.stdout)
 
     f = host.file(config_file_path)
     assert f.exists

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -2,10 +2,8 @@ sdkman_dir = '/home/jenkins/.sdkman'
 
 
 def script_wrap(cmds):
-    sdk_init_tmpl = 'export SDKMAN_DIR={0} && source {0}/bin/sdkman-init.sh'
-    sdk_init = sdk_init_tmpl.format(sdkman_dir)
-    result_cmds = [sdk_init] + cmds
-    return "/bin/bash -c '{0}'".format('; '.join(result_cmds))
+    # run as interactive shell to ensure .bashrc is sourced
+    return "/bin/bash -i -c '{0}'".format('; '.join(cmds))
 
 
 def check_run_for_rc_and_result(cmds, expected, host, check_stderr=False):

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -43,3 +43,7 @@ def test_offline(host):
     cmds = ['sdk list gradle']
     expected = 'Offline: only showing installed gradle versions'
     check_run_for_rc_and_result(cmds, expected, host)
+
+    cmds = ['sdk offline disable', 'sdk list gradle']
+    expected = 'Available Gradle Versions'
+    check_run_for_rc_and_result(cmds, expected, host)


### PR DESCRIPTION
## Description

Offline mode set by `sdkman_offline_mode` in PR https://github.com/Comcast/ansible-sdkman/pull/39 does not work as expected.

`sdk offline enable/disable` only sets environment variables that do not persist across shell sessions, as seen from the [source code](https://github.com/sdkman/sdkman-cli/blob/master/src/main/bash/sdkman-offline.sh).

To be able to persist this option, we would have to write into a shell config, similarly to how `sdkman` itself writes the initialization scripts [during the installation step](https://github.com/sdkman/sdkman-hooks/blob/db3708792c75d38464d320ea3c569b947f39ac9b/app/views/install.scala.txt#L266-L287).

This PR adds/updates `export SDKMAN_OFFLINE_MODE='true'` or `export SDKMAN_OFFLINE_MODE='false'` to the shell configs where the initialization scripts were also initially added. The list of shell configs to check are mirrored from the [possible list](https://github.com/sdkman/sdkman-hooks/blob/db3708792c75d38464d320ea3c569b947f39ac9b/app/views/install.scala.txt#L41-L44) that the init script could be written to.

This just sets the default initial value when entering the shell, and can be overridden with `sdk offline disable` when working with the CLI.

This implementation is purposely left fairly generic as other potential environment variables can be added, working around the limited set of configuration options in the SDKMAN config file.

## Tests
### Offline mode tests
In offline mode, `sdk list <candidate>` would only display installed versions:
```
jenkins@90ebb34aea80:/$ sdk offline enable
Offline mode enabled.

jenkins@90ebb34aea80:/$ sdk list gradle
--------------------------------------------------------------------------------
Offline: only showing installed gradle versions
--------------------------------------------------------------------------------
 > 2.10
--------------------------------------------------------------------------------
* - installed                                                                   
> - currently in use                                                            
--------------------------------------------------------------------------------
```

Add check for `Offline: only showing installed gradle versions` text when offline mode had been enabled by role.

An additional testing step is added after that to ensure that `sdk offline disable` correctly disables offline mode.

### Fixing existing tests
In the current state, I think the tests are not covering the use cases as expected.

When setting `MOLECULE_USER=root` and running the role with `sdkman_user: jenkins`, it is installing SDKMAN to `jenkins` while initially logging in as `root`.

The expected behaviour should be that only when running as the `jenkins` user, the `sdk` CLI is available. Instead of explicitly setting the environment variables like `SDK_DIR` and sourcing the init script, the tests should be running commands as `jenkins` to ensure that the correct env vars are sourced and `sdk` is initialized.