### PR TITLE
Fix CI by adjusting Java candidate/version

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,7 +15,7 @@
           version: 1.8.9
       sdkman_install_packages:
         - candidate: java
-          version: 8.0.212-zulu
+          version: 8.0.232.hs-adpt
         - candidate: gradle
           version: '4.6'
         - candidate: gradle

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -66,8 +66,10 @@ def test_update_alternatives(host):
     check_run_for_rc_and_result(
         cmds, expected, host, check_stderr=True, as_interactive=False)
 
+    java_parent_dir = '.sdkman/candidates/java/8.0.232.hs-adpt/bin'
+
     cmds = ['readlink -f /usr/bin/java']
-    expected = '.sdkman/candidates/java/8.0.212-zulu/bin/java'
+    expected = java_parent_dir + '/java'
     check_run_for_rc_and_result(cmds, expected, host)
 
     cmds = ['/usr/bin/javac -version']
@@ -76,5 +78,5 @@ def test_update_alternatives(host):
         cmds, expected, host, check_stderr=True, as_interactive=False)
 
     cmds = ['readlink -f /usr/bin/javac']
-    expected = '.sdkman/candidates/java/8.0.212-zulu/bin/javac'
+    expected = java_parent_dir + '/javac'
     check_run_for_rc_and_result(cmds, expected, host)


### PR DESCRIPTION
Switch to (latest) AdoptOpenJDK 8 until something more dynamic is
supported from the SDK candidates API.