### PR TITLE
Fix issue with python package libselinux-python3  

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
         - any
     - name: EL
       versions:
+        - '8'
         - '7'
         - '6'
     - name: Fedora

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -6,6 +6,9 @@ driver:
 lint:
   name: yamllint
 platforms:
+  - name: centos8
+    image: centos:8.1.1911
+    user: ${MOLECULE_USER}
   - name: centos7
     image: centos:7.6.1810
     user: ${MOLECULE_USER}

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -3,7 +3,7 @@
 FROM {{ item.image }}
 
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v dnf) ]; then  if [[ $(cat /etc/os-release | grep PLATFORM_ID) == *'el8'* ]]; then dnf --assumeyes install python36 sudo python36-devel python3-dnf bash && update-alternatives --set python /usr/bin/python3 ; else dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash;  fi; dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates shadow; fi

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,6 +11,7 @@
   vars:
     params:
       files:
+        - '{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml'
         - '{{ ansible_distribution }}.yml'
         - '{{ ansible_os_family }}.yml'
         - default.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,7 +15,7 @@
           version: 1.8.9
       sdkman_install_packages:
         - candidate: java
-          version: 8.0.232.hs-adpt
+          version: 8.0.242.hs-adpt
         - candidate: gradle
           version: '4.6'
         - candidate: gradle

--- a/vars/RedHat8.yml
+++ b/vars/RedHat8.yml
@@ -1,0 +1,11 @@
+---
+# vars for Redhat systems
+system_packages:
+  - curl
+  - findutils
+  - libselinux-python3
+  - libstdc++
+  - tar
+  - unzip
+  - which
+  - zip


### PR DESCRIPTION
The new versions of Centos/Redhat changed the libselinux package and deprecated python 2.
No default python is set after installing the python package.
That created two issues: one the sdkman package fails to install due the lack of libselinux-python3, and two, the molecule test fails due to missing packages and configurations at the default docker image available in the official centos dockerhub repository.

This PR fixes both things. They need to go together otherwise it wont be possible to test the fix for the python package which only fails for el8 onwards. 
 