### PR TITLE
Add an optional localpath parameter when installing candidates. This …

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Here's an example!
         - { candidate: gradle, version: 2.14.1 }
         - { candidate: maven, version: 3.5.0 }
         - { candidate: maven, version: 3.3.9 }
+        # Use this syntax if you want SDKMAN to be aware of packages installed *without* SDKMAN, e.g. Oracle JDKs
+        - { candidate: java, version: 1.8.0-oracle, localpath: /Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk }
       sdkman_defaults:
         gradle: '3.5'
         maven: 3.3.9

--- a/tasks/sdkman.yml
+++ b/tasks/sdkman.yml
@@ -27,7 +27,7 @@
 - name: Install SDK candidates/versions
   shell: >-
     . {{ sdkman_dir }}/bin/sdkman-init.sh &&
-    sdk install {{ item.candidate }} {{ item.version | default('') }}
+    sdk install {{ item.candidate }} {{ item.version | default('') }} {{ item.localpath | default('') }}
   args:
     executable: /bin/bash
   loop: '{{ sdkman_install_packages }}'


### PR DESCRIPTION
…enables SDKMAN to become aware of JVM tools that have not been installed via SDKMAN itself