### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here's an example!
 ```yaml
 - hosts: servers
   roles:
-    - role: Comcast.sdkman
+    - role: comcast.sdkman
       sdkman_user: vagrant
       sdkman_group: vagrant
       sdkman_auto_answer: true


### PR DESCRIPTION
In the example code, the first letter of Comcast is capital. But, I think it should be lower case, since the capital case version didn't work for me.