### PR TITLE
Fix permission errors when checking SDKMAN install for different user

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -57,6 +57,7 @@
   stat:
     path: '{{ sdkman_dir }}/bin/sdkman-init.sh'
   register: sdkman_init
+  become: yes
 
 # Install SDKMAN if not uninstalled
 - block:


### PR DESCRIPTION
When SDKMAN is installed for a different user than the one Ansible is connecting with for the first time, it is likely that the user home directory permissions do not allow path traversal and/or file reading for the Ansible user:

![image](https://github.com/Comcast/ansible-sdkman/assets/7822554/3474b5cf-9c66-4ab0-bd56-1c19f0247d70)

To fix the problem, let's switch to the root user for this check, which should work in virtually every reasonable case.