### PR TITLE
Fix uninstall to be idempotent

### DIFF
--- a/tasks/sdkman.yml
+++ b/tasks/sdkman.yml
@@ -47,8 +47,10 @@
   loop: '{{ sdkman_uninstall_packages }}'
   register: sdk_uninstall
   changed_when: >-
-    not item.candidate + ' ' + item.version + ' is not installed.'
-    in sdk_uninstall.stdout
+    'is not installed' not in sdk_uninstall.stderr
+  failed_when: >-
+    sdk_uninstall.rc != 0 and
+    'is not installed' not in sdk_uninstall.stderr
 
 - name: Get SDK defaults
   shell: . {{ sdkman_dir }}/bin/sdkman-init.sh && sdk current {{ item }}


### PR DESCRIPTION
I was playing with the uninstall and noticed it explodes if you re-run a second time and the package isn't there:

```
TASK [comcast.sdkman : Uninstall SDK candidates/versions] ************************************************************************************************************************************
failed: [localhost] (item={'candidate': 'java', 'version': '17.0.11-tem'}) => {"ansible_loop_var": "item", "changed": true, "cmd": ". /home/alyssa/.sdkman/bin/sdkman-init.sh && sdk uninstall java 17.0.11-tem", "delta": "0:00:00.628336", "end": "2025-06-04 16:14:44.773058", "item": {"candidate": "java", "version": "17.0.11-tem"}, "msg": "non-zero return code", "rc": 1, "start": "2025-06-04 16:14:44.144722", "stderr": "java 17.0.11-tem is not installed on your system", "stderr_lines": ["java 17.0.11-tem is not installed on your system"], "stdout": "", "stdout_lines": []}
```

Fix is basically the same as in https://github.com/Comcast/ansible-sdkman/pull/51 - I also made the check a bit less specific since it looks like it's already changed once (mine says "not installed on your system" rather than "not installed.")

## Testing

Happy to add automated tests if that's relatively doable, I'm fairly new to ansible so not sure where to start with that atm. But I've tested it manually with the following steps.

1. Install two versions of ant with the following config:

```
  - role: comcast.sdkman
    tags: ant-test
    sdkman_install_packages:
      - { candidate: ant, version: "1.9.7" }
      - { candidate: ant, version: "1.10.14" }
```

2. Update the config to uninstall one of them:

```
  - role: comcast.sdkman
    tags: ant-test
    sdkman_install_packages:
      - { candidate: ant, version: "1.10.14" }
    sdkman_uninstall_packages:
      - { candidate: ant, version: "1.9.7" }
```

It's removed and correctly identified as changed:

```
TASK [comcast.sdkman : Install SDK candidates/versions] ********************************************************************************************************************************
ok: [localhost] => (item={'candidate': 'ant', 'version': '1.10.14'})

TASK [comcast.sdkman : Uninstall SDK candidates/versions] ******************************************************************************************************************************
changed: [localhost] => (item={'candidate': 'ant', 'version': '1.9.7'})
```
      
3. Run again with no changes to config, there's no error and check shows as "ok" (not changed):

```
TASK [comcast.sdkman : Install SDK candidates/versions] ********************************************************************************************************************************
ok: [localhost] => (item={'candidate': 'ant', 'version': '1.10.14'})

TASK [comcast.sdkman : Uninstall SDK candidates/versions] ******************************************************************************************************************************
ok: [localhost] => (item={'candidate': 'ant', 'version': '1.9.7'})
```